### PR TITLE
fix writing to 2nd FAT with 1-fat filesystem

### DIFF
--- a/src/FatLib/FatVolume.cpp
+++ b/src/FatLib/FatVolume.cpp
@@ -55,7 +55,7 @@ bool FatCache::sync() {
       goto fail;
     }
     // mirror second FAT
-    if (m_status & CACHE_STATUS_MIRROR_FAT) {
+    if ( (m_vol->m_fatCount == 2) && (m_status & CACHE_STATUS_MIRROR_FAT) ) {
       uint32_t lbn = m_lbn + m_vol->blocksPerFat();
       if (!m_vol->writeBlock(lbn, m_block.data)) {
         DBG_FAIL_MACRO;


### PR DESCRIPTION
- fixes https://github.com/adafruit/Adafruit_SPIFlash/issues/21

SdFat assume filesystem always have 2 FAT (which is true for SD Card), but optional for other type of storage (in our case external flash). We did you modification to add 1-FAT support to SdFat but not complete. the SdFat PR will hopefully nail it

@ladyada for review