### PR TITLE
Allow USE_STANDARD_SPI_LIBRARY to be set by compilation definition flag

### DIFF
--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -77,7 +77,9 @@
  * USE_STANDARD_SPI_LIBRARY is two, the SPI port can be selected with the
  * constructors SdFat(SPIClass* spiPort) and SdFatEX(SPIClass* spiPort).
  */
+#ifndef USE_STANDARD_SPI_LIBRARY
 #define USE_STANDARD_SPI_LIBRARY 0
+#endif
 //------------------------------------------------------------------------------
 /**
  * If the symbol ENABLE_SOFTWARE_SPI_CLASS is nonzero, the class SdFatSoftSpi


### PR DESCRIPTION
I had to do this to allow alternative SPI when using Platformio. Here's how this is used in platformio.ini:
```
build_flags =
  -DUSE_STANDARD_SPI_LIBRARY=2
```