### PR TITLE
Allow Debug Macros via Build Flag

### DIFF
--- a/src/common/DebugMacros.h
+++ b/src/common/DebugMacros.h
@@ -27,7 +27,9 @@
 #include "SysCall.h"
 
 // 0 - disable, 1 - fail, halt 2 - fail, halt, warn
+#ifndef USE_DBG_MACROS
 #define USE_DBG_MACROS 0
+#endif
 
 #if USE_DBG_MACROS
 #include "Arduino.h"


### PR DESCRIPTION
This allows the debug macros to be enabled via build flag, without editing the library file. 