### PR TITLE
Update  Rp2040SdioSetup example for Feather RP2040 Adalogger

### DIFF
--- a/examples/Rp2040SdioSetup/Rp2040SdioSetup.ino
+++ b/examples/Rp2040SdioSetup/Rp2040SdioSetup.ino
@@ -26,7 +26,7 @@ Wires should be short since signals can be as faster than 50 MHz.
 // Example GPIO definitions I use for debug. Edit for your setup.
 // Run this example as is to print the symbol for your variant.
 //
-#if defined(ARDUINO_ADAFRUIT_METRO_RP2040)
+#if defined(ARDUINO_ADAFRUIT_METRO_RP2040) || defined(ARDUINO_ADAFRUIT_FEATHER_RP2040_ADALOGGER)
 #define RP_CLK_GPIO 18
 #define RP_CMD_GPIO 19
 #define RP_DAT0_GPIO 20  // DAT1: GPIO21, DAT2: GPIO22, DAT3: GPIO23.


### PR DESCRIPTION
Simple update to `Rp2040SdioSetup` example preproc logic to include Feather RP2040 Adalogger.

**BEFORE**
<img width="877" height="442" alt="Screenshot from 2025-07-31 08-37-37" src="https://github.com/user-attachments/assets/f9971957-42ba-4951-b254-c79b29e39e7d" />


**AFTER**
<img width="877" height="442" alt="Screenshot from 2025-07-31 08-38-03" src="https://github.com/user-attachments/assets/a0374503-2746-4599-b2a8-602b93200ff9" />
