### PR TITLE
SdFormatter.ino -> Universal 1MHz fallback

### DIFF
--- a/examples/SdFormatter/SdFormatter.ino
+++ b/examples/SdFormatter/SdFormatter.ino
@@ -206,8 +206,27 @@ void setup() {
   // Select and initialize proper card driver.
   m_card = cardFactory.newCard(SD_CONFIG);
   if (!m_card || m_card->errorCode()) {
-    sdError("card init failed.");
-    return;
+    // Try slow 1 MHz fallback if fast init fails
+    SdSpiConfig slowCfg(SD_CS_PIN, SHARED_SPI, SD_SCK_MHZ(1));
+    SdCard* slowCard = cardFactory.newCard(slowCfg);
+    if (!slowCard || slowCard->errorCode()) {
+      sdError("card init failed.");
+      return;
+    }
+    m_card = slowCard;
+  }
+
+  // Retry sectorCount() slowly if fast attempt fails
+  uint32_t scFast = m_card->sectorCount();
+  if (!scFast) {
+    SdSpiConfig slowCfg(SD_CS_PIN, SHARED_SPI, SD_SCK_MHZ(1));
+    SdCard* slowCard = cardFactory.newCard(slowCfg);
+    if (slowCard) {
+      uint32_t scSlow = slowCard->sectorCount();
+      if (scSlow > 0) {
+        m_card = slowCard;   // adopt working slow interface
+      }
+    }
   }
 
   cardSectorCount = m_card->sectorCount();
@@ -248,7 +267,12 @@ void setup() {
     return;
   }
   if (c == 'E' || c == 'F') {
-    eraseCard();
+    // XTSD/Zetta and some flash-based cards do not support SD erase commands
+    if (!m_card->erase(0, 0)) {
+      cout << F("\nErase unsupported — skipping erase step\n");
+    } else {
+      eraseCard();
+    }
   }
   if (c == 'F' || c == 'Q') {
     formatCard();

--- a/examples/SdFormatter/SdFormatter.ino
+++ b/examples/SdFormatter/SdFormatter.ino
@@ -203,30 +203,16 @@ void setup() {
   // Read any existing Serial data.
   clearSerialInput();
 
-  // Select and initialize proper card driver.
+  // Initialize card and fall back to 1 MHz if init or sectorCount() fails
   m_card = cardFactory.newCard(SD_CONFIG);
-  if (!m_card || m_card->errorCode()) {
-    // Try slow 1 MHz fallback if fast init fails
+  if (!m_card || m_card->errorCode() || m_card->sectorCount() == 0) {
     SdSpiConfig slowCfg(SD_CS_PIN, SHARED_SPI, SD_SCK_MHZ(1));
     SdCard* slowCard = cardFactory.newCard(slowCfg);
-    if (!slowCard || slowCard->errorCode()) {
+    if (!slowCard || slowCard->errorCode() || slowCard->sectorCount() == 0) {
       sdError("card init failed.");
       return;
     }
     m_card = slowCard;
-  }
-
-  // Retry sectorCount() slowly if fast attempt fails
-  uint32_t scFast = m_card->sectorCount();
-  if (!scFast) {
-    SdSpiConfig slowCfg(SD_CS_PIN, SHARED_SPI, SD_SCK_MHZ(1));
-    SdCard* slowCard = cardFactory.newCard(slowCfg);
-    if (slowCard) {
-      uint32_t scSlow = slowCard->sectorCount();
-      if (scSlow > 0) {
-        m_card = slowCard;   // adopt working slow interface
-      }
-    }
   }
 
   cardSectorCount = m_card->sectorCount();


### PR DESCRIPTION
This adds a universal fast→1 MHz fallback for SD init and sectorCount() to improve compatibility with XTSD/Zetta and other timing-sensitive cards. Tested on Feather RP2040 and Feather ESP32 V2, with normal SD cards unaffected.

PR #42 attempted to do this, but was ESP32 specific. This removes any processor architecture and only slows down to 1MHz when necessary. 